### PR TITLE
Add QR scanner to input fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
  "futures",
  "hex",
  "leptos",
+ "leptos-qr-scanner",
  "leptos_meta",
  "lightning-invoice",
  "rexie",
@@ -1547,6 +1548,18 @@ dependencies = [
  "server_fn",
  "tracing",
  "typed-builder",
+]
+
+[[package]]
+name = "leptos-qr-scanner"
+version = "0.1.0"
+source = "git+https://github.com/elsirion/leptos-qr-scanner?rev=75e976e99d9c1ed64921081a23f7da823d2a0b6d#75e976e99d9c1ed64921081a23f7da823d2a0b6d"
+dependencies = [
+ "js-sys",
+ "leptos",
+ "serde",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ fedimint-ln-client = { git = "https://github.com/fedimint/fedimint", rev = "183b
 futures = "0.3.28"
 hex = "0.4.3"
 leptos = { version = "0.4.8", features = ["csr"] }
+leptos-qr-scanner = { git = "https://github.com/elsirion/leptos-qr-scanner", rev = "75e976e99d9c1ed64921081a23f7da823d2a0b6d" }
 leptos_meta = { version = "0.4.8", features = ["csr"] }
 lightning-invoice = { version = "0.21.0", features = [ "serde" ] }
 

--- a/src/components/submit_form.rs
+++ b/src/components/submit_form.rs
@@ -1,5 +1,6 @@
 use leptos::ev::KeyboardEvent;
 use leptos::*;
+use leptos_qr_scanner::Scan;
 
 use crate::components::SubmitButton;
 
@@ -18,42 +19,82 @@ where
     let (value, set_value) = create_signal(cx, String::new());
 
     let button_is_disabled = Signal::derive(cx, move || loading.get() || value.get().is_empty());
+    let scan_disabled = Signal::derive(cx, move || loading.get());
+
+    let (scan, set_scan) = create_signal(cx, false);
+
+    let textarea = view! {cx,
+        <textarea
+          class="my-8 w-full text-xl font-body text-gray-600 border-gray-400 placeholder:text-gray-400 ring-0 focus:border-blue-400 focus:ring-0"
+          rows="4"
+          required
+          placeholder=placeholder.clone()
+          prop:disabled=move || loading.get()
+          prop:value=move || value.get()
+          on:keydown=move |ev: KeyboardEvent| {
+            if ev.key() == "Enter" {
+              ev.prevent_default();
+              on_submit(value.get());
+            }
+          }
+          on:input=move |ev| {
+            let val = event_target_value(&ev);
+            set_value.set(val);
+          }
+          on:paste=move |ev| {
+            let val = event_target_value(&ev);
+            set_value.set(val);
+          }
+        />
+    };
+
+    let qr_scanner = view! { cx,
+        <Scan
+          active=scan
+          on_scan=move |invite| {
+            set_scan.set(false);
+            set_value.set(invite.clone());
+            on_submit(invite);
+          }
+          class="my-8"
+        />
+    };
 
     view! { cx,
       <form on:submit=|ev| ev.prevent_default()>
 
       <p class="font-body text-gray-600 text-xl">{description}</p>
-      <textarea
-        class="my-8 w-full text-xl font-body text-gray-600 border-gray-400 placeholder:text-gray-400 ring-0 focus:border-blue-400 focus:ring-0"
-        rows="4"
-        required
-        placeholder=placeholder
-        prop:disabled=move || loading.get()
-        prop:value=move || value.get()
-        on:keydown=move |ev: KeyboardEvent| {
-          if ev.key() == "Enter" {
-              ev.prevent_default();
-              on_submit(value.get());
-          }
-        }
-        on:input=move |ev| {
-          let val = event_target_value(&ev);
-          set_value.set(val);
-        }
-        on:paste=move |ev| {
-          let val = event_target_value(&ev);
-          set_value.set(val);
-        }
-      />
+      <Show
+        when=move || scan.get()
+        fallback=move |_| textarea.clone()
+      >
+        {qr_scanner.clone()}
+      </Show>
 
+      <div class="flex space-x-4">
       <SubmitButton
-          class="w-full"
+        class="w-5/6"
         loading=loading
         disabled=button_is_disabled
         on_click=move |_| {
           on_submit(value.get());
         }
       >{submit_label}</SubmitButton>
+      <SubmitButton
+        class="w-1/6"
+        loading=loading
+        disabled=scan_disabled
+        on_click=move |_| {
+          set_scan.set(!scan.get());
+        }
+      >{move || {
+        if scan.get() {
+          "Stop"
+        } else {
+          "Scan"
+        }
+      }}</SubmitButton>
+      </div>
       </form>
     }
 }


### PR DESCRIPTION
Now every input field has an optional QR scanner. The button probably needs some refactoring (should be a different class than the submit one I guess), but it works and makes the app more usable in practice.

1. QR scanning disabled by default

![Screenshot 2023-08-20 at 17-19-12 Fedimint Web Client](https://github.com/elsirion/fedimint-leptos-test/assets/84478054/f1cf92a9-244c-46f3-867b-2a17c03ad0e3)

2. Scanning, text field is hidden

![Screenshot 2023-08-20 at 17-19-27 Fedimint Web Client](https://github.com/elsirion/fedimint-leptos-test/assets/84478054/af0f815b-62a3-48d7-ae30-c38bce051f3d)

3. Scan successful, submit is triggered automatically while the text field shows the scanned input.
4. 
![Screenshot 2023-08-20 at 17-22-23 Fedimint Web Client](https://github.com/elsirion/fedimint-leptos-test/assets/84478054/c50404ae-ecdd-4a97-8882-915a2a9eacd5)
