### PR TITLE
.envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /dist
 
 /node_modules
+
+.direnv


### PR DESCRIPTION
Thanks to `direnv` no need to enter `nix develop` "by hand" anymore (see https://zero-to-flakes.com/direnv/)

> You can now cd into the project directory in a terminal and the devshell will be automatically activated.

^ https://zero-to-flakes.com/direnv#add-a-envrc

